### PR TITLE
Fix code scanning alert no. 11: Uncontrolled command line

### DIFF
--- a/WebGoat/App_Code/Util.cs
+++ b/WebGoat/App_Code/Util.cs
@@ -13,6 +13,11 @@ namespace OWASP.WebGoat.NET.App_Code
         
         public static int RunProcessWithInput(string cmd, string args, string input)
         {
+            if (!IsValidArgument(args))
+            {
+                throw new ArgumentException("Invalid arguments provided.");
+            }
+
             ProcessStartInfo startInfo = new ProcessStartInfo
             {
                 WorkingDirectory = Settings.RootDir,
@@ -89,6 +94,17 @@ namespace OWASP.WebGoat.NET.App_Code
                 }
             }
         }
+        private static bool IsValidArgument(string args)
+        {
+            // Allow only alphanumeric characters and a few safe symbols
+            foreach (char c in args)
+            {
+                if (!char.IsLetterOrDigit(c) && c != '-' && c != '_' && c != ' ' && c != '.')
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
     }
 }
-


### PR DESCRIPTION
Fixes [https://github.com/charith-gunasekara-webjet/cghas-demo-csharp/security/code-scanning/11](https://github.com/charith-gunasekara-webjet/cghas-demo-csharp/security/code-scanning/11)

To fix the problem, we need to validate and sanitize the `args` parameter before using it in the `ProcessStartInfo.Arguments`. This can be done by implementing a whitelist of allowed arguments or by escaping potentially dangerous characters. In this case, we will implement a simple validation to ensure that the `args` parameter only contains allowed characters (alphanumeric and a few safe symbols).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
