### PR TITLE
Fix code scanning alert no. 23: Creating an ASP.NET debug binary may reveal sensitive information

### DIFF
--- a/WebGoat/Web.config
+++ b/WebGoat/Web.config
@@ -40,7 +40,7 @@ http://msdn2.microsoft.com/en-us/library/b5ysx397.aspx
     <httpRuntime enableHeaderChecking="false"/>
     <!-- this is how you would set secure and http only on session cookies -->
     <httpCookies httpOnlyCookies="false" requireSSL="false"/>
-    <compilation defaultLanguage="C#" debug="true" targetFramework="4.8">
+    <compilation defaultLanguage="C#" targetFramework="4.8">
       <assemblies>
         <!--add assembly="System.Web.Mobile, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" /-->
         <add assembly="Mono.Data.Sqlite"/>


### PR DESCRIPTION
Fixes [https://github.com/charith-gunasekara-webjet/cghas-demo-csharp/security/code-scanning/23](https://github.com/charith-gunasekara-webjet/cghas-demo-csharp/security/code-scanning/23)

To fix the problem, we need to remove the `debug` flag from the `Web.config` file or set it to `false`. This change ensures that the application does not expose sensitive debugging information and performs optimally in a production environment.

- Locate the `Web.config` file in the project directory.
- Find the `<compilation>` element within the `<system.web>` section.
- Remove the `debug="true"` attribute or set it to `false`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
