### PR TITLE
Fix code scanning alert no. 29: SQL query built from user-controlled sources

### DIFF
--- a/WebGoat/App_Code/DB/SqliteDbProvider.cs
+++ b/WebGoat/App_Code/DB/SqliteDbProvider.cs
@@ -526,7 +526,7 @@ namespace OWASP.WebGoat.NET.App_Code.DB
 
         public DataSet GetEmailByName(string name)
         {
-            string sql = "select firstName, lastName, email from Employees where firstName like '" + name + "%' or lastName like '" + name + "%'";
+            string sql = "select firstName, lastName, email from Employees where firstName like @name or lastName like @name";
             
             
             using (SqliteConnection connection = new SqliteConnection(_connectionString))
@@ -534,6 +534,7 @@ namespace OWASP.WebGoat.NET.App_Code.DB
                 connection.Open();
 
                 SqliteDataAdapter da = new SqliteDataAdapter(sql, connection);
+                da.SelectCommand.Parameters.AddWithValue("@name", name + "%");
                 DataSet ds = new DataSet();
                 da.Fill(ds);
 
@@ -543,7 +544,7 @@ namespace OWASP.WebGoat.NET.App_Code.DB
                     return ds;
             }
         }
-
+
         public string GetEmailByCustomerNumber(string num)
         {
             string output = "";
@@ -554,8 +555,9 @@ namespace OWASP.WebGoat.NET.App_Code.DB
                 {
                     connection.Open();
 
-                    string sql = "select email from CustomerLogin where customerNumber = " + num;
+                    string sql = "select email from CustomerLogin where customerNumber = @num";
                     SqliteCommand cmd = new SqliteCommand(sql, connection);
+                    cmd.Parameters.AddWithValue("@num", num);
                     output = (string)cmd.ExecuteScalar();
                 }
                 
@@ -568,10 +570,10 @@ namespace OWASP.WebGoat.NET.App_Code.DB
             
             return output;
         }
-
+
         public DataSet GetCustomerEmails(string email)
         {
-            string sql = "select email from CustomerLogin where email like '" + email + "%'";
+            string sql = "select email from CustomerLogin where email like @Email";
             
             
             using (SqliteConnection connection = new SqliteConnection(_connectionString))
@@ -579,6 +581,7 @@ namespace OWASP.WebGoat.NET.App_Code.DB
                 connection.Open();
 
                 SqliteDataAdapter da = new SqliteDataAdapter(sql, connection);
+                da.SelectCommand.Parameters.AddWithValue("@Email", email + "%");
                 DataSet ds = new DataSet();
                 da.Fill(ds);
 


### PR DESCRIPTION
Fixes [https://github.com/charith-gunasekara-webjet/cghas-demo-csharp/security/code-scanning/29](https://github.com/charith-gunasekara-webjet/cghas-demo-csharp/security/code-scanning/29)

To fix the problem, we should use parameterized queries instead of string concatenation to construct SQL queries. This approach ensures that user input is treated as a parameter and not as part of the SQL command, thus preventing SQL injection attacks.

In the provided code snippets, we need to modify the methods `GetEmailByCustomerNumber`, `GetEmailByName`, and `GetCustomerEmails` in the `SqliteDbProvider` class to use parameterized queries. This involves creating `SqliteCommand` objects with parameters and adding the user input as parameters to these commands.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
