### PR TITLE
Fix code scanning alert no. 30: 'requireSSL' attribute is not set to true

### DIFF
--- a/WebGoat/Web.config
+++ b/WebGoat/Web.config
@@ -39,7 +39,7 @@ http://msdn2.microsoft.com/en-us/library/b5ysx397.aspx
     <!-- this disables header checking -->
     <httpRuntime enableHeaderChecking="false"/>
     <!-- this is how you would set secure and http only on session cookies -->
-    <httpCookies httpOnlyCookies="false" requireSSL="false"/>
+    <httpCookies httpOnlyCookies="false" requireSSL="true"/>
     <compilation defaultLanguage="C#" targetFramework="4.8">
       <assemblies>
         <!--add assembly="System.Web.Mobile, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" /-->
@@ -50,7 +50,7 @@ http://msdn2.microsoft.com/en-us/library/b5ysx397.aspx
     <customErrors mode="Off"/>
     <!-- set up users -->
     <authentication mode="Forms">
-      <forms name="customer_login" timeout="30" loginUrl="~/WebGoatCoins/CustomerLogin.aspx" requireSSL="false" protection="All" path="/">
+      <forms name="customer_login" timeout="30" loginUrl="~/WebGoatCoins/CustomerLogin.aspx" requireSSL="true" protection="All" path="/">
         <credentials passwordFormat="Clear">
           <user name="admin" password="admin"/>
           <user name="mario" password="luigi"/>


### PR DESCRIPTION
Fixes [https://github.com/charith-gunasekara-webjet/cghas-demo-csharp/security/code-scanning/30](https://github.com/charith-gunasekara-webjet/cghas-demo-csharp/security/code-scanning/30)

To fix the problem, we need to set the `requireSSL` attribute to `true` in both the `<httpCookies>` and `<forms>` elements within the `Web.config` file. This change will ensure that cookies and forms are transmitted securely over HTTPS, protecting sensitive data from being intercepted.

1. Locate the `<httpCookies>` element and change the `requireSSL` attribute from `false` to `true`.
2. Locate the `<forms>` element and change the `requireSSL` attribute from `false` to `true`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
