### PR TITLE
Fix code scanning alert no. 27: SQL query built from user-controlled sources

### DIFF
--- a/WebGoat/App_Code/DB/SqliteDbProvider.cs
+++ b/WebGoat/App_Code/DB/SqliteDbProvider.cs
@@ -265,7 +265,7 @@ namespace OWASP.WebGoat.NET.App_Code.DB
 
         public string AddComment(string productCode, string email, string comment)
         {
-            string sql = "insert into Comments(productCode, email, comment) values ('" + productCode + "','" + email + "','" + comment + "');";
+            string sql = "insert into Comments(productCode, email, comment) values (@productCode, @Email, @Comment)";
             string output = null;
             
             try
@@ -275,6 +275,9 @@ namespace OWASP.WebGoat.NET.App_Code.DB
                 {
                     connection.Open();
                     SqliteCommand command = new SqliteCommand(sql, connection);
+                    command.Parameters.AddWithValue("@productCode", productCode);
+                    command.Parameters.AddWithValue("@Email", email);
+                    command.Parameters.AddWithValue("@Comment", comment);
                     command.ExecuteNonQuery();
                 }
             }
@@ -544,7 +547,8 @@ namespace OWASP.WebGoat.NET.App_Code.DB
                     return ds;
             }
         }
-
+
+
         public string GetEmailByCustomerNumber(string num)
         {
             string output = "";
@@ -570,7 +574,8 @@ namespace OWASP.WebGoat.NET.App_Code.DB
             
             return output;
         }
-
+
+
         public DataSet GetCustomerEmails(string email)
         {
             string sql = "select email from CustomerLogin where email like @Email";


### PR DESCRIPTION
Fixes [https://github.com/charith-gunasekara-webjet/cghas-demo-csharp/security/code-scanning/27](https://github.com/charith-gunasekara-webjet/cghas-demo-csharp/security/code-scanning/27)

To fix the SQL injection vulnerability, we should use parameterized queries instead of string concatenation. This involves using placeholders for user inputs in the SQL query and then binding the actual values to these placeholders. This approach ensures that user inputs are treated as data rather than executable code, thus preventing SQL injection attacks.

In the `AddComment` method, we will replace the string concatenation with a parameterized query. We will use the `SqliteCommand.Parameters.AddWithValue` method to bind the user inputs to the query parameters.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
