### PR TITLE
Fix code scanning alert no. 11: Uncontrolled command line

### DIFF
--- a/WebGoat/App_Code/Util.cs
+++ b/WebGoat/App_Code/Util.cs
@@ -96,10 +96,13 @@ namespace OWASP.WebGoat.NET.App_Code
         }
         private static bool IsValidArgument(string args)
         {
-            // Allow only alphanumeric characters and a few safe symbols
-            foreach (char c in args)
+            // Define a whitelist of allowed arguments
+            string[] allowedArguments = { "arg1", "arg2", "arg3" }; // Replace with actual allowed arguments
+            string[] providedArguments = args.Split(' ');
+
+            foreach (string arg in providedArguments)
             {
-                if (!char.IsLetterOrDigit(c) && c != '-' && c != '_' && c != ' ' && c != '.' && c != '/')
+                if (!Array.Exists(allowedArguments, element => element == arg))
                 {
                     return false;
                 }


### PR DESCRIPTION
Fixes [https://github.com/charith-gunasekara-webjet/cghas-demo-csharp/security/code-scanning/11](https://github.com/charith-gunasekara-webjet/cghas-demo-csharp/security/code-scanning/11)

To fix the problem, we need to enhance the validation of the `args` parameter to ensure it does not contain any potentially harmful input. One effective way is to use a whitelist approach for the arguments, similar to the command validation. We can define a set of allowed arguments and ensure that the provided arguments match this set. Additionally, we should avoid directly using user input in the command execution.

1. Define a whitelist of allowed arguments.
2. Validate the `args` parameter against this whitelist.
3. If the arguments are not valid, throw an exception.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
