### PR TITLE
Fix code scanning alert no. 25: XML injection

### DIFF
--- a/WebGoat/Content/XMLInjection.aspx.cs
+++ b/WebGoat/Content/XMLInjection.aspx.cs
@@ -61,19 +61,20 @@ namespace OWASP.WebGoat.NET
 
         private void WriteXML()
         {
-            string xml = "<?xml version=\"1.0\" standalone=\"yes\"?>"+ Environment.NewLine +"<users>" + Environment.NewLine;
-            foreach (XmlUser user in users)
+            using (XmlWriter writer = XmlWriter.Create(Server.MapPath("/App_Data/XmlInjectionUsers.xml"), new XmlWriterSettings { Indent = true, Encoding = Encoding.UTF8 }))
             {
-                xml += "<user>" + Environment.NewLine;
-                xml += "<name>" + user.Name + "</name>" + Environment.NewLine;
-                xml += "<email>" + user.Email + "</email>" + Environment.NewLine;
-                xml += "</user>" + Environment.NewLine;
+                writer.WriteStartDocument();
+                writer.WriteStartElement("users");
+                foreach (XmlUser user in users)
+                {
+                    writer.WriteStartElement("user");
+                    writer.WriteElementString("name", user.Name);
+                    writer.WriteElementString("email", user.Email);
+                    writer.WriteEndElement();
+                }
+                writer.WriteEndElement();
+                writer.WriteEndDocument();
             }
-            xml += "</users>" +Environment.NewLine;
-
-            XmlTextWriter writer = new XmlTextWriter(Server.MapPath("/App_Data/XmlInjectionUsers.xml"), Encoding.UTF8);
-            writer.WriteRaw(xml);
-            writer.Close();
         }
     }
 


### PR DESCRIPTION
Fixes [https://github.com/charith-gunasekara-webjet/cghas-demo-csharp/security/code-scanning/25](https://github.com/charith-gunasekara-webjet/cghas-demo-csharp/security/code-scanning/25)

To fix the XML injection issue, we should avoid using the `WriteRaw` method with untrusted user input. Instead, we should use the high-level XML APIs provided by .NET, which automatically escape user content. This ensures that any user-provided data is safely included in the XML document without the risk of injection.

Specifically, we will modify the `WriteXML` method to use `XmlWriter` methods like `WriteStartElement`, `WriteElementString`, and `WriteEndElement` to construct the XML document. This approach will automatically handle any necessary escaping of user input.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
