### PR TITLE
Fix code scanning alert no. 21: Regular expression injection

### DIFF
--- a/WebGoat/Content/RegexDoS.aspx.cs
+++ b/WebGoat/Content/RegexDoS.aspx.cs
@@ -17,7 +17,7 @@ namespace OWASP.WebGoat.NET
         /// </summary>
         protected void btnCreate_Click(object sender, EventArgs e)
         {
-            string userName = txtUsername.Text;
+            string userName = Regex.Escape(txtUsername.Text);
             string password = txtPassword.Text;
 
             Regex testPassword = new Regex(userName);


### PR DESCRIPTION
Fixes [https://github.com/charith-gunasekara-webjet/cghas-demo-csharp/security/code-scanning/21](https://github.com/charith-gunasekara-webjet/cghas-demo-csharp/security/code-scanning/21)

To fix the problem, we need to sanitize the user input before using it to construct a regular expression. This can be done using the `Regex.Escape` method, which escapes any special characters in the input, ensuring that it is treated as a literal string in the regular expression. This change will prevent any malicious input from altering the behavior of the regular expression.

The specific changes required are:
1. Use `Regex.Escape` on the `userName` variable before constructing the `Regex` object.
2. Ensure that the functionality remains the same by only modifying the relevant lines of code.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
