### PR TITLE
Fix code scanning alert no. 5: URL redirection from remote source

### DIFF
--- a/WebGoat/WebGoatCoins/CustomerLogin.aspx.cs
+++ b/WebGoat/WebGoatCoins/CustomerLogin.aspx.cs
@@ -66,10 +66,19 @@ namespace OWASP.WebGoat.NET.WebGoatCoins
             
             string returnUrl = Request.QueryString["ReturnUrl"];
             
-            if (returnUrl == null) 
+            if (returnUrl == null || !IsValidReturnUrl(returnUrl)) 
                 returnUrl = "/WebGoatCoins/MainPage.aspx";
                 
             Response.Redirect(returnUrl);        
+        }
+        private bool IsValidReturnUrl(string url)
+        {
+            Uri result;
+            if (Uri.TryCreate(url, UriKind.Relative, out result))
+            {
+                return true;
+            }
+            return false;
         }
     }
 }


### PR DESCRIPTION
Fixes [https://github.com/charith-gunasekara-webjet/cghas-demo-csharp/security/code-scanning/5](https://github.com/charith-gunasekara-webjet/cghas-demo-csharp/security/code-scanning/5)

To fix the problem, we need to validate the `returnUrl` parameter before using it in the redirect. One way to do this is to maintain a list of authorized URLs and check if the `returnUrl` is in this list. Alternatively, we can ensure that the `returnUrl` is either a relative URL or belongs to a known good host.

The best way to fix the problem without changing existing functionality is to validate the `returnUrl` against a list of known good URLs or ensure it is a relative URL. This can be done by modifying the `ButtonLogOn_Click` method to include this validation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
